### PR TITLE
Allocate by using `new Array(n)`

### DIFF
--- a/packages/jsx/src/index.js
+++ b/packages/jsx/src/index.js
@@ -56,13 +56,13 @@ const jsx: typeof React.createElement = function(
     }
     newProps.className = className
 
-    let childrenLength = arguments.length
+    let argsLength = arguments.length
 
-    let createElementArgArray = Array(childrenLength)
+    let createElementArgArray = new Array(argsLength)
     createElementArgArray[0] = type
     createElementArgArray[1] = newProps
 
-    for (let i = 2; i < childrenLength; i++) {
+    for (let i = 2; i < argsLength; i++) {
       createElementArgArray[i] = arguments[i]
     }
 


### PR DESCRIPTION
Array(n) is causing some deopts in v8 - https://github.com/babel/babel/issues/6233#issuecomment-329055890