### PR TITLE
Add typings for next/utils

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,11 @@
     "./dist/index.cjs.js": "./dist/index.browser.cjs.js",
     "./dist/index.es.js": "./dist/index.browser.es.js"
   },
+  "types": "types/index.d.ts",
   "license": "MIT",
+  "scripts": {
+    "test:typescript": "dtslint types"
+  },
   "repository": "https://github.com/emotion-js/next/tree/master/packages/serialize",
   "publishConfig": {
     "access": "public"
@@ -17,5 +21,8 @@
     "src",
     "dist"
   ],
-  "umd:main": "./dist/index.min.js"
+  "umd:main": "./dist/index.min.js",
+  "devDependencies": {
+    "dtslint": "^0.3.0"
+  }
 }

--- a/packages/utils/types/index.d.ts
+++ b/packages/utils/types/index.d.ts
@@ -31,5 +31,7 @@ export interface ScopedInsertableStyles {
 export const isBrowser: boolean;
 export const shouldSerializeToReactTree: boolean;
 
-export function getRegisteredStyles(registered: RegisteredCache, registeredStyles: Array<string>, classNames: string): string;
+export type Interpolation = any;
+
+export function getRegisteredStyles(registered: RegisteredCache, registeredStyles: Array<Interpolation>, classNames: string): string;
 export function insertStyles(context: CSSContextType, insertable: ScopedInsertableStyles): string | true | void;

--- a/packages/utils/types/index.d.ts
+++ b/packages/utils/types/index.d.ts
@@ -1,0 +1,35 @@
+// Definitions by: Junyoung Clare Jang <https://github.com/Ailrun>
+// TypeScript Version: 2.2
+
+export interface RegisteredCache {
+  [key: string]: string;
+}
+
+export interface StyleSheet {
+  container: HTMLElement;
+  insert(rule: string): void;
+  flush(): void;
+}
+
+export interface CSSContextType {
+  stylis: (key: string, value: string) => Array<string>;
+  inserted: {
+    [key: string]: string | true;
+  };
+  registered: RegisteredCache;
+  sheet: StyleSheet;
+  theme: object;
+  key: string;
+  compat?: true;
+}
+
+export interface ScopedInsertableStyles {
+  name: string;
+  styles: string;
+}
+
+export const isBrowser: boolean;
+export const shouldSerializeToReactTree: boolean;
+
+export function getRegisteredStyles(registered: RegisteredCache, registeredStyles: Array<string>, classNames: string): string;
+export function insertStyles(context: CSSContextType, insertable: ScopedInsertableStyles): string | true | void;

--- a/packages/utils/types/test.ts
+++ b/packages/utils/types/test.ts
@@ -1,5 +1,5 @@
 import {
-  CSSContextType, RegisteredCache, ScopedInsertableStyles, StyleSheet,
+  CSSContextType, Interpolation, RegisteredCache, ScopedInsertableStyles, StyleSheet,
   getRegisteredStyles, insertStyles, isBrowser, shouldSerializeToReactTree,
 } from '@emotion/utils';
 

--- a/packages/utils/types/test.ts
+++ b/packages/utils/types/test.ts
@@ -1,0 +1,42 @@
+import {
+  CSSContextType, RegisteredCache, ScopedInsertableStyles, StyleSheet,
+  getRegisteredStyles, insertStyles, isBrowser, shouldSerializeToReactTree,
+} from '@emotion/utils';
+
+declare const testContext: CSSContextType;
+declare const testRegisteredCache: RegisteredCache;
+
+getRegisteredStyles(testRegisteredCache, [], 'abc');
+getRegisteredStyles(testRegisteredCache, [], 'abc def');
+getRegisteredStyles(testRegisteredCache, [], 'dead end');
+getRegisteredStyles(testRegisteredCache, ['color: red;'], 'black parade');
+// $ExpectError
+getRegisteredStyles();
+// $ExpectError
+getRegisteredStyles(testRegisteredCache);
+
+insertStyles(testContext, {
+  name: 'abc',
+  styles: 'color: green;background: red;',
+});
+// $ExpectError
+insertStyles();
+// $ExpectError
+insertStyles(testContext);
+// $ExpectError
+insertStyles(testContext, {});
+// $ExpectError
+insertStyles(testContext, {
+  name: 'abc',
+});
+// $ExpectError
+insertStyles(testContext, {
+  styles: 'font-size: 18px;',
+});
+
+const test0: boolean = isBrowser;
+// $ExpectError
+const test1: number = isBrowser;
+const test2: boolean = shouldSerializeToReactTree;
+// $ExpectError
+const test3: number = shouldSerializeToReactTree;

--- a/packages/utils/types/tsconfig.json
+++ b/packages/utils/types/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "module": "commonjs",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "target": "es5",
+    "typeRoots": [
+      "../"
+    ],
+    "types": []
+  },
+  "include": [
+    "./*.ts",
+    "./*.tsx"
+  ]
+}

--- a/packages/utils/types/tslint.json
+++ b/packages/utils/types/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "array-type": [true, "generic"]
+    }
+}


### PR DESCRIPTION
Add typings for next/util.
However, I have one question. `registeredStyles` in `getRegisteredStyles` have `string[]` type, but actually it is of `Interpolation[]` (currently `any[]`) based on https://github.com/emotion-js/next/blob/4130d67313a234de923047a4f2f65535caf33ec1/packages/core/src/jsx.js#L36-L48, isn't it?